### PR TITLE
Remove dependency on packed_simd by using SIMD intrinsics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,6 @@ dependencies = [
  "arrayref",
  "criterion",
  "librsync",
- "packed_simd_2",
  "quickcheck",
  "quickcheck_macros",
  "rand",
@@ -272,12 +271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
 name = "librsync"
 version = "0.2.1"
 source = "git+https://github.com/goffrie/librsync-rs?rev=56e7646d133c3174656b66c61f6259d6154a8873#56e7646d133c3174656b66c61f6259d6154a8873"
@@ -343,16 +336,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
-dependencies = [
- "cfg-if",
- "libm",
-]
 
 [[package]]
 name = "plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = [
 
 [dependencies]
 arrayref = "0.3.6"
-packed_simd = { version = "0.3.4", package = "packed_simd_2" }
 
 [dev-dependencies]
 librsync = { git = "https://github.com/goffrie/librsync-rs", rev = "56e7646d133c3174656b66c61f6259d6154a8873", default-features = false }

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ A faster implementation of [librsync](https://github.com/librsync/librsync) in
 pure Rust, using SIMD operations where available. Note that only the legacy MD4
 format is supported, not BLAKE2.
 
-Rust nightly is currently required because of
-[packed\_simd](https://github.com/rust-lang/packed_simd). Only x86 and x86-64
-architectures are currently supported.
+Only x86 and x86-64 architectures are currently supported for SIMD.
 
 ## The rsync algorithm
 This crate offers three major APIs:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -25,7 +25,6 @@ name = "fast_rsync"
 version = "0.1.4-alpha.0"
 dependencies = [
  "arrayref",
- "packed_simd_2",
 ]
 
 [[package]]
@@ -69,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
 name = "librsync"
 version = "0.2.0"
 source = "git+https://github.com/goffrie/librsync-rs?rev=ab9c427b5b20624fe533ad0247fe0f9c3460245e#ab9c427b5b20624fe533ad0247fe0f9c3460245e"
@@ -100,16 +93,6 @@ checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
-dependencies = [
- "cfg-if",
- "libm",
 ]
 
 [[package]]

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -75,11 +75,15 @@ impl Crc {
         {
             if is_x86_feature_detected!("avx2") {
                 imp!(#[target_feature(enable = "avx2")] unsafe fn imp_avx2);
-                unsafe { return imp_avx2(self, buf); }
+                unsafe {
+                    return imp_avx2(self, buf);
+                }
             }
             if is_x86_feature_detected!("sse2") {
                 imp!(#[target_feature(enable = "sse2")] unsafe fn imp_sse2);
-                unsafe { return imp_sse2(self, buf); }
+                unsafe {
+                    return imp_sse2(self, buf);
+                }
             }
         }
         imp!(fn imp_baseline);

--- a/src/md4/x86_simd_transpose.rs
+++ b/src/md4/x86_simd_transpose.rs
@@ -1,100 +1,86 @@
 //! Utilities for loading and transposing data from memory.
 //! This is useful for SPMD-style operations.
-use arrayref::{array_ref, array_refs, mut_array_refs};
-use packed_simd::{shuffle, u32x4, u32x8};
+use arrayref::array_ref;
 
-pub struct LE;
+use self::arch::{
+    __m128i, __m256i, _mm256_castsi128_si256, _mm256_inserti128_si256, _mm256_unpackhi_epi32,
+    _mm256_unpackhi_epi64, _mm256_unpacklo_epi32, _mm256_unpacklo_epi64, _mm_loadu_si128,
+    _mm_unpackhi_epi32, _mm_unpackhi_epi64, _mm_unpacklo_epi32, _mm_unpacklo_epi64,
+};
+#[cfg(target_arch = "x86")]
+use std::arch::x86 as arch;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64 as arch;
 
-pub trait Endian {
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    fn load(x: &[u8; 4]) -> u32;
-}
-
-impl Endian for LE {
-    #[inline(always)]
-    fn load(x: &[u8; 4]) -> u32 {
-        u32::from_le_bytes(*x)
-    }
-}
-
-/// `movdqu`
 #[inline(always)]
-fn load_u32x4<E: Endian>(slice: &[u8; 16]) -> u32x4 {
-    let (a, b, c, d) = array_refs![slice, 4, 4, 4, 4];
-    u32x4::new(E::load(a), E::load(b), E::load(c), E::load(d))
+/// Loads four u32s (little-endian), potentially unaligned
+unsafe fn load_u32x4(slice: &[u8; 16]) -> __m128i {
+    _mm_loadu_si128(slice as *const [u8; 16] as *const __m128i)
 }
 
 /// Load 32 bytes (1 u32x8) out of each lane of `data`, transposed.
+#[inline]
 #[target_feature(enable = "avx2")]
-unsafe fn load_transpose8<E: Endian>(data: [&[u8; 32]; 8], out: &mut [u32x8; 8]) {
+unsafe fn load_transpose8(data: [&[u8; 32]; 8]) -> [__m256i; 8] {
     #[inline(always)]
-    fn cat2x4(a: u32x4, b: u32x4) -> u32x8 {
-        // `vinserti32x4`
-        shuffle!(a, b, [0, 1, 2, 3, 4, 5, 6, 7])
-    }
-
-    #[inline(always)]
-    fn unpacklo2x4(a: u32x8, b: u32x8) -> u32x8 {
-        // `vpunpckldq`
-        shuffle!(a, b, [0, 8, 1, 9, 4, 12, 5, 13])
-    }
-
-    #[inline(always)]
-    fn unpackhi2x4(a: u32x8, b: u32x8) -> u32x8 {
-        // `vpunpckhdq`
-        shuffle!(a, b, [2, 10, 3, 11, 6, 14, 7, 15])
+    /// Concatenate two u32x4s into a single u32x8
+    unsafe fn cat2x4(a: __m128i, b: __m128i) -> __m256i {
+        // `vinserti128`
+        _mm256_inserti128_si256(_mm256_castsi128_si256(a), b, 1)
     }
 
     let l04 = cat2x4(
-        load_u32x4::<E>(array_ref![data[0], 0, 16]),
-        load_u32x4::<E>(array_ref![data[4], 0, 16]),
+        load_u32x4(array_ref![data[0], 0, 16]),
+        load_u32x4(array_ref![data[4], 0, 16]),
     );
     let l15 = cat2x4(
-        load_u32x4::<E>(array_ref![data[1], 0, 16]),
-        load_u32x4::<E>(array_ref![data[5], 0, 16]),
+        load_u32x4(array_ref![data[1], 0, 16]),
+        load_u32x4(array_ref![data[5], 0, 16]),
     );
     let l26 = cat2x4(
-        load_u32x4::<E>(array_ref![data[2], 0, 16]),
-        load_u32x4::<E>(array_ref![data[6], 0, 16]),
+        load_u32x4(array_ref![data[2], 0, 16]),
+        load_u32x4(array_ref![data[6], 0, 16]),
     );
     let l37 = cat2x4(
-        load_u32x4::<E>(array_ref![data[3], 0, 16]),
-        load_u32x4::<E>(array_ref![data[7], 0, 16]),
+        load_u32x4(array_ref![data[3], 0, 16]),
+        load_u32x4(array_ref![data[7], 0, 16]),
     );
     let h04 = cat2x4(
-        load_u32x4::<E>(array_ref![data[0], 16, 16]),
-        load_u32x4::<E>(array_ref![data[4], 16, 16]),
+        load_u32x4(array_ref![data[0], 16, 16]),
+        load_u32x4(array_ref![data[4], 16, 16]),
     );
     let h15 = cat2x4(
-        load_u32x4::<E>(array_ref![data[1], 16, 16]),
-        load_u32x4::<E>(array_ref![data[5], 16, 16]),
+        load_u32x4(array_ref![data[1], 16, 16]),
+        load_u32x4(array_ref![data[5], 16, 16]),
     );
     let h26 = cat2x4(
-        load_u32x4::<E>(array_ref![data[2], 16, 16]),
-        load_u32x4::<E>(array_ref![data[6], 16, 16]),
+        load_u32x4(array_ref![data[2], 16, 16]),
+        load_u32x4(array_ref![data[6], 16, 16]),
     );
     let h37 = cat2x4(
-        load_u32x4::<E>(array_ref![data[3], 16, 16]),
-        load_u32x4::<E>(array_ref![data[7], 16, 16]),
+        load_u32x4(array_ref![data[3], 16, 16]),
+        load_u32x4(array_ref![data[7], 16, 16]),
     );
     // [data[0][0], data[1][0], data[0][1], data[1][1], data[4][0], data[5][0], data[4][1], data[5][1]]
-    let a0145 = unpacklo2x4(l04, l15);
+    let a0145 = _mm256_unpacklo_epi32(l04, l15);
     // [data[0][2], data[1][2], data[0][3], data[1][3], data[4][2], data[5][2], data[4][3], data[5][3]]
-    let b0145 = unpackhi2x4(l04, l15);
-    let a2367 = unpacklo2x4(l26, l37);
-    let b2367 = unpackhi2x4(l26, l37);
-    let c0145 = unpacklo2x4(h04, h15);
-    let d0145 = unpackhi2x4(h04, h15);
-    let c2367 = unpacklo2x4(h26, h37);
-    let d2367 = unpackhi2x4(h26, h37);
-    out[0] = shuffle!(a0145, a2367, [0, 1, 8, 9, 4, 5, 12, 13]);
-    out[1] = shuffle!(a0145, a2367, [2, 3, 10, 11, 6, 7, 14, 15]);
-    out[2] = shuffle!(b0145, b2367, [0, 1, 8, 9, 4, 5, 12, 13]);
-    out[3] = shuffle!(b0145, b2367, [2, 3, 10, 11, 6, 7, 14, 15]);
-    out[4] = shuffle!(c0145, c2367, [0, 1, 8, 9, 4, 5, 12, 13]);
-    out[5] = shuffle!(c0145, c2367, [2, 3, 10, 11, 6, 7, 14, 15]);
-    out[6] = shuffle!(d0145, d2367, [0, 1, 8, 9, 4, 5, 12, 13]);
-    out[7] = shuffle!(d0145, d2367, [2, 3, 10, 11, 6, 7, 14, 15]);
+    let b0145 = _mm256_unpackhi_epi32(l04, l15);
+    let a2367 = _mm256_unpacklo_epi32(l26, l37);
+    let b2367 = _mm256_unpackhi_epi32(l26, l37);
+    let c0145 = _mm256_unpacklo_epi32(h04, h15);
+    let d0145 = _mm256_unpackhi_epi32(h04, h15);
+    let c2367 = _mm256_unpacklo_epi32(h26, h37);
+    let d2367 = _mm256_unpackhi_epi32(h26, h37);
+    [
+        _mm256_unpacklo_epi64(a0145, a2367),
+        _mm256_unpackhi_epi64(a0145, a2367),
+        _mm256_unpacklo_epi64(b0145, b2367),
+        _mm256_unpackhi_epi64(b0145, b2367),
+        _mm256_unpacklo_epi64(c0145, c2367),
+        _mm256_unpackhi_epi64(c0145, c2367),
+        _mm256_unpacklo_epi64(d0145, d2367),
+        _mm256_unpackhi_epi64(d0145, d2367),
+    ]
 }
 
 macro_rules! get_blocks {
@@ -103,63 +89,43 @@ macro_rules! get_blocks {
 
 #[inline]
 #[target_feature(enable = "avx2")]
-// use a return pointer to avoid initialization cost (LLVM can't figure
-// out that it's elideable)
-pub unsafe fn load_16x8<'a, E: Endian, F: Fn(usize) -> &'a [u8; 64]>(
-    blocks: &mut [u32x8; 16],
-    data: F,
-) {
-    let (a, b) = mut_array_refs![blocks, 8, 8];
-    load_transpose8::<E>(get_blocks!(data, (0 1 2 3 4 5 6 7), 0, 32), a);
-    load_transpose8::<E>(get_blocks!(data, (0 1 2 3 4 5 6 7), 32, 32), b);
+pub unsafe fn load_16x8_avx2<'a, F: Fn(usize) -> &'a [u8; 64]>(data: F) -> [__m256i; 16] {
+    // We're using transmute to concatenate arrays; not ideal, but it works
+    core::mem::transmute::<[[__m256i; 8]; 2], [__m256i; 16]>([
+        load_transpose8(get_blocks!(data, (0 1 2 3 4 5 6 7), 0, 32)),
+        load_transpose8(get_blocks!(data, (0 1 2 3 4 5 6 7), 32, 32)),
+    ])
 }
 
-macro_rules! load_16x4 {
-    ($f: ident, $feature: tt) => {
-        #[inline]
-        #[target_feature(enable = $feature)]
-        pub unsafe fn $f<'a, E: Endian, F: Fn(usize) -> &'a [u8; 64]>(
-            blocks: &mut [u32x4; 16],
-            data: F,
-        ) {
-            /// Load 16 bytes (1 u32x4) out of each lane of `data`, transposed.
-            #[target_feature(enable = $feature)]
-            unsafe fn load_transpose4<E: Endian>(data: [&[u8; 16]; 4], out: &mut [u32x4; 4]) {
-                #[inline(always)]
-                fn unpacklo4(a: u32x4, b: u32x4) -> u32x4 {
-                    // `punpckldq`
-                    shuffle!(a, b, [0, 4, 1, 5])
-                }
-
-                #[inline(always)]
-                fn unpackhi4(a: u32x4, b: u32x4) -> u32x4 {
-                    // `vpunpckhdq`
-                    shuffle!(a, b, [2, 6, 3, 7])
-                }
-
-                let i0 = load_u32x4::<E>(data[0]);
-                let i1 = load_u32x4::<E>(data[1]);
-                let i2 = load_u32x4::<E>(data[2]);
-                let i3 = load_u32x4::<E>(data[3]);
-                // [data[0][0], data[1][0], data[0][1], data[1][1]]
-                let l01 = unpacklo4(i0, i1);
-                // [data[0][2], data[1][2], data[0][3], data[1][3]]
-                let h01 = unpackhi4(i0, i1);
-                let l23 = unpacklo4(i2, i3);
-                let h23 = unpackhi4(i2, i3);
-                out[0] = shuffle!(l01, l23, [0, 1, 4, 5]);
-                out[1] = shuffle!(l01, l23, [2, 3, 6, 7]);
-                out[2] = shuffle!(h01, h23, [0, 1, 4, 5]);
-                out[3] = shuffle!(h01, h23, [2, 3, 6, 7]);
-            }
-
-            let (a, b, c, d) = mut_array_refs![blocks, 4, 4, 4, 4];
-            load_transpose4::<E>(get_blocks!(data, (0 1 2 3), 0, 16), a);
-            load_transpose4::<E>(get_blocks!(data, (0 1 2 3), 16, 16), b);
-            load_transpose4::<E>(get_blocks!(data, (0 1 2 3), 32, 16), c);
-            load_transpose4::<E>(get_blocks!(data, (0 1 2 3), 48, 16), d);
-        }
-    };
+/// Load 16 bytes (1 u32x4) out of each lane of `data`, transposed.
+#[inline]
+#[target_feature(enable = "sse2")]
+unsafe fn load_transpose4(data: [&[u8; 16]; 4]) -> [__m128i; 4] {
+    let i0 = load_u32x4(data[0]);
+    let i1 = load_u32x4(data[1]);
+    let i2 = load_u32x4(data[2]);
+    let i3 = load_u32x4(data[3]);
+    // [data[0][0], data[1][0], data[0][1], data[1][1]]
+    let l01 = _mm_unpacklo_epi32(i0, i1);
+    // [data[0][2], data[1][2], data[0][3], data[1][3]]
+    let h01 = _mm_unpackhi_epi32(i0, i1);
+    let l23 = _mm_unpacklo_epi32(i2, i3);
+    let h23 = _mm_unpackhi_epi32(i2, i3);
+    [
+        _mm_unpacklo_epi64(l01, l23),
+        _mm_unpackhi_epi64(l01, l23),
+        _mm_unpacklo_epi64(h01, h23),
+        _mm_unpackhi_epi64(h01, h23),
+    ]
 }
 
-load_16x4!(load_16x4_sse2, "sse2");
+#[inline]
+#[target_feature(enable = "sse2")]
+pub unsafe fn load_16x4_sse2<'a, F: Fn(usize) -> &'a [u8; 64]>(data: F) -> [__m128i; 16] {
+    core::mem::transmute::<[[__m128i; 4]; 4], [__m128i; 16]>([
+        load_transpose4(get_blocks!(data, (0 1 2 3), 0, 16)),
+        load_transpose4(get_blocks!(data, (0 1 2 3), 16, 16)),
+        load_transpose4(get_blocks!(data, (0 1 2 3), 32, 16)),
+        load_transpose4(get_blocks!(data, (0 1 2 3), 48, 16)),
+    ])
+}


### PR DESCRIPTION
The resulting code is a little ugly, but not too bad.

This allows the crate to compile on stable.