### PR TITLE
Shrink main hashmap after blocks are no longer being added

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -184,6 +184,12 @@ impl<'a> Signature<'a> {
                 .or_default()
                 .insert(block.crypto_hash, idx as u32);
         }
+
+        // Multiple blocks having the same `Crc` value means that the hashmap will reserve more
+        // capacity than needed. This is particularly noticable when `self.blocks` contains a very
+        // large number of values
+        blocks.shrink_to_fit();
+
         IndexedSignature {
             signature_type: self.signature_type,
             block_size: self.block_size,


### PR DESCRIPTION
I think this is pretty self explanatory. This change alone dropped my RAM usage significantly when using a signature that contains 10s of millions of blocks. 