### PR TITLE
Make the second layer hashmap more memory efficient

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -149,7 +149,7 @@ pub fn diff(
             {
                 if let Some(blocks) = signature.blocks.get(&crc) {
                     let digest = md4(&data[here..here + block_size as usize]);
-                    if let Some(&idx) = blocks.get(&digest[..crypto_hash_size]) {
+                    if let Some(&idx) = blocks.get(&&digest[..crypto_hash_size]) {
                         // match found
                         state.copy(
                             idx as u64 * block_size as u64,

--- a/src/hashmap_variant.rs
+++ b/src/hashmap_variant.rs
@@ -1,5 +1,22 @@
+//! Contains a hashmap optimized for the second layer of the
+//! [`IndexedSignature`][crate::signature::IndexedSignature]
+
 use std::{collections::HashMap, hash::Hash, mem};
 
+/// A single entry optimized hashmap intended for use in the second layer map in
+/// [`IndexedSignature`][crate::signature::IndexedSignature]
+///
+/// The [`IndexedSignature`][crate::signature::IndexedSignature] contains a two-layer hashmap. The
+/// first layer is keyed on a cheap, but weak, rolling hash that maps to a slower, but stronger,
+/// hash to better guarantee an accurate match on the block.
+///
+/// This means that there are only multiple entries in the second layer map when there is a hash
+/// collision from the weak hash in the first layer which is rare. We can use this to optimize the
+/// map for the common case of a single entry while [`Box`]ing the fallback of two or more entries.
+///
+/// With this the current use case of `SecondLayerMap<&[u8], u32>` takes up 24 bytes on 64-bit
+/// systems while `HashMap<&[u8, u32>` takes 48. Beyond that a [`SecondLayerMap`] consists of just
+/// a match and an if
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SecondLayerMap<K, V>
 where
@@ -23,6 +40,7 @@ impl<K, V> SecondLayerMap<K, V>
 where
     K: Eq + Hash,
 {
+    /// Analogous to [`HashMap::insert`]
     pub fn insert(&mut self, key: K, val: V) -> Option<V> {
         let old_state = mem::replace(self, Self::Empty);
 
@@ -44,6 +62,7 @@ where
         ret
     }
 
+    /// Analogous to [`HashMap::get`]
     pub fn get(&self, needle: &K) -> Option<&V> {
         match self {
             Self::Single(key, val) => {

--- a/src/hashmap_variant.rs
+++ b/src/hashmap_variant.rs
@@ -1,0 +1,60 @@
+use std::{collections::HashMap, hash::Hash, mem};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SecondLayerMap<K, V>
+where
+    K: Eq + Hash,
+{
+    Empty,
+    Single(K, V),
+    TwoOrMore(Box<HashMap<K, V>>),
+}
+
+impl<K, V> Default for SecondLayerMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+impl<K, V> SecondLayerMap<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn insert(&mut self, key: K, val: V) -> Option<V> {
+        let old_state = mem::replace(self, Self::Empty);
+
+        let (new_state, ret) = match old_state {
+            Self::Empty => (Self::Single(key, val), None),
+            Self::Single(old_key, old_val) => {
+                let mut map = Box::new(HashMap::new());
+                map.insert(key, val);
+                let ret = map.insert(old_key, old_val);
+                (Self::TwoOrMore(map), ret)
+            }
+            Self::TwoOrMore(mut map) => {
+                let ret = map.insert(key, val);
+                (Self::TwoOrMore(map), ret)
+            }
+        };
+
+        *self = new_state;
+        ret
+    }
+
+    pub fn get(&self, needle: &K) -> Option<&V> {
+        match self {
+            Self::Single(key, val) => {
+                if needle == key {
+                    Some(&val)
+                } else {
+                    None
+                }
+            }
+            Self::TwoOrMore(map) => map.get(needle),
+            Self::Empty => None,
+        }
+    }
+}

--- a/src/hashmap_variant.rs
+++ b/src/hashmap_variant.rs
@@ -29,7 +29,7 @@ where
         let (new_state, ret) = match old_state {
             Self::Empty => (Self::Single(key, val), None),
             Self::Single(old_key, old_val) => {
-                let mut map = Box::new(HashMap::new());
+                let mut map = Box::new(HashMap::with_capacity(2));
                 map.insert(key, val);
                 let ret = map.insert(old_key, old_val);
                 (Self::TwoOrMore(map), ret)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod consts;
 mod crc;
 mod diff;
 mod hasher;
-mod md4;
 mod hashmap_variant;
+mod md4;
 mod patch;
 mod signature;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod crc;
 mod diff;
 mod hasher;
 mod md4;
+mod hashmap_variant;
 mod patch;
 mod signature;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use crate::consts::{BLAKE2_MAGIC, MD4_MAGIC};
 use crate::crc::Crc;
 use crate::hasher::BuildCrcHasher;
+use crate::hashmap_variant::SecondLayerMap;
 use crate::md4::{md4, md4_many, MD4_SIZE};
 
 /// An rsync signature.
@@ -33,7 +34,7 @@ pub struct IndexedSignature<'a> {
     pub(crate) block_size: u32,
     pub(crate) crypto_hash_size: u32,
     /// crc -> crypto hash -> block index
-    pub(crate) blocks: HashMap<Crc, HashMap<&'a [u8], u32>, BuildCrcHasher>,
+    pub(crate) blocks: HashMap<Crc, SecondLayerMap<&'a [u8], u32>, BuildCrcHasher>,
 }
 
 /// The hash type used with within the signature.
@@ -176,7 +177,7 @@ impl<'a> Signature<'a> {
 
     /// Convert a signature to a form suitable for computing deltas.
     pub fn index(&self) -> IndexedSignature<'a> {
-        let mut blocks: HashMap<Crc, HashMap<&[u8], u32>, BuildCrcHasher> =
+        let mut blocks: HashMap<Crc, SecondLayerMap<&[u8], u32>, BuildCrcHasher> =
             HashMap::with_capacity_and_hasher(self.blocks.len(), BuildCrcHasher::default());
         for (idx, block) in self.blocks.iter().enumerate() {
             blocks


### PR DESCRIPTION
The bulk of `IndexedSignature` is taken up by the internal hashmap. The second layer of this hashmap almost always has 1 entry (when I was testing manually with over 7 million blocks, there were still only one value within +99.7% of the second layer hashmaps).

These changes optimize the second layer hashmap for the common case of a single entry where a `std::mem::size_of::<SecondLayerMap<&[u8], u32>>()` shows 24 bytes while `std::mem::size_of<HashMap<&[u8], u32>>()` shows 48 bytes on my machine.

This should also make `.get()` a bit faster with a single entry as well, but it was never a significant amount of time when I've been profiling, so I saw a less than 2% improvement on a couple benchmarks with no regressions.