### PR TITLE
fix: correct occured to occurred typo in doc comment

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -22,7 +22,7 @@ const MAX_CRC_COLLISIONS: u32 = 1024;
 pub enum DiffError {
     /// Indicates the signature is invalid or unsupported
     InvalidSignature,
-    /// Indicates an IO error occured when writing the delta
+    /// Indicates an IO error occurred when writing the delta
     Io(io::Error),
 }
 


### PR DESCRIPTION
Fixes a typo in the Io error message comment in src/diff.rs.

occured -> occurred